### PR TITLE
Fix stack overflow in TreapMapBuilder.clear()

### DIFF
--- a/collect/src/main/kotlin/com/certora/collect/TreapMapBuilder.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMapBuilder.kt
@@ -15,6 +15,8 @@ internal class TreapMapBuilder<@Treapable K, V>(
     override fun get(key: K): V? = map.get(key)
     override fun getOrDefault(key: K, defaultValue: @UnsafeVariance V): V = map.getOrDefault(key, defaultValue)
 
+    override fun clear() { map = map.clear() }
+
     override fun remove(key: K): V? {
         val oldMap = map
         map = map.remove(key)

--- a/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
+++ b/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
@@ -123,6 +123,19 @@ abstract class TreapMapTest {
     }
 
     @Test
+    fun clear() {
+        val m = makeMap()
+        val k = makeKey(1)
+        val v = Object()
+        m.put(k, v)
+        assertEquals(1, m.size)
+        assertEquals(v, m[k])
+        m.clear()
+        assertEquals(0, m.size)
+        assertNull(m[k])
+    }
+
+    @Test
     fun addMany() {
         val b = makeBaseline()
         val m = makeMap()

--- a/collect/src/test/kotlin/com/certora/collect/TreapSetTest.kt
+++ b/collect/src/test/kotlin/com/certora/collect/TreapSetTest.kt
@@ -125,6 +125,18 @@ abstract class TreapSetTest {
         }
     }
 
+    @Test
+    fun clear() {
+        val s = makeSet()
+        val k = makeKey(1)
+        s.add(k)
+        assertEquals(1, s.size)
+        assertTrue(k in s)
+        s.clear()
+        assertEquals(0, s.size)
+        assertFalse(k in s)
+    }
+
     fun randomHashObjectMaybeNull(rand: Random): TestKey? {
         val r = rand.nextInt()
         if (nullKeysAllowed) {


### PR DESCRIPTION
We were inheriting `clear` from `AbstractMutableMap`, which calls `entries.clear()`, which in turn calls `map.clear()`, which then calls `entries.clear()`...etc.