### PR TITLE
TreapMap union and intersection

### DIFF
--- a/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
@@ -41,6 +41,12 @@ internal class EmptyTreapMap<@Treapable K, V> private constructor() : TreapMap<K
             else -> put(key, v)
         }
 
+    override fun union(m: Map<K, V>, merger: (K, V, V) -> V): TreapMap<K, V> = putAll(m)
+    override fun parallelUnion(m: Map<K, V>, parallelThresholdLog2: Int, merger: (K, V, V) -> V): TreapMap<K, V> = putAll(m)
+
+    override fun intersect(m: Map<K, V>, merger: (K, V, V) -> V): TreapMap<K, V> = this
+    override fun parallelIntersect(m: Map<K, V>, parallelThresholdLog2: Int, merger: (K, V, V) -> V): TreapMap<K, V> = this
+
     override fun merge(m: Map<K, V>, merger: (K, V?, V?) -> V?): TreapMap<K, V> {
         var map: TreapMap<K, V> = this
         for ((key, value) in m) {

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
@@ -33,6 +33,20 @@ internal class SortedTreapMap<@Treapable K, V>(
 
     override fun arbitraryOrNull(): Map.Entry<K, V>? = MapEntry(key, value)
 
+    override fun getShallowUnionMerger(
+        merger: (K, V, V) -> V
+    ): (SortedTreapMap<K, V>, SortedTreapMap<K, V>) -> SortedTreapMap<K, V> = { t1, t2 ->
+        val v = merger(t1.key, t1.value, t2.value)
+        SortedTreapMap(t1.key, v, t1.left, t1.right)
+    }
+
+    override fun getShallowIntersectMerger(
+        merger: (K, V, V) -> V
+    ): (SortedTreapMap<K, V>, SortedTreapMap<K, V>) -> SortedTreapMap<K, V>? = { t1, t2 ->
+        val v = merger(t1.key, t1.value, t2.value)
+        SortedTreapMap(t1.key, v, t1.left, t1.right)
+    }
+
     override fun getShallowMerger(merger: (K, V?, V?) -> V?): (SortedTreapMap<K, V>?, SortedTreapMap<K, V>?) -> SortedTreapMap<K, V>? = { t1, t2 ->
         val k = (t1 ?: t2)!!.key
         val v1 = t1?.value

--- a/collect/src/main/kotlin/com/certora/collect/Treap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/Treap.kt
@@ -174,7 +174,9 @@ internal fun <@Treapable T, S : Treap<T, S>> Treap<T, S>?.split(key: TreapKey<T>
         }
     }
 }
-internal class Split<@Treapable T, S : Treap<T, S>>(var left: S?, var right: S?, var duplicate: S?)
+internal class Split<@Treapable T, S : Treap<T, S>>(var left: S?, var right: S?, var duplicate: S?) {
+    override fun toString(): String = "Split(left=$left, right=$right, duplicate=$duplicate)"
+}
 
 
 /**

--- a/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
@@ -31,7 +31,7 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
     /**
         Calls [action] for each entry in the map.
 
-        Traverses the treap without allocating temprarory storage, which may be more efficient than `entries.forEach`.
+        Traverses the treap without allocating temporary storage, which may be more efficient than `entries.forEach`.
      */
     public fun forEachEntry(action: (Map.Entry<K, V>) -> Unit): Unit
 

--- a/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
@@ -28,13 +28,40 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
      */
     public fun arbitraryOrNull(): Map.Entry<K, V>?
 
+    /**
+        Calls [action] for each entry in the map.
+
+        Traverses the treap without allocating temprarory storage, which may be more efficient than `entries.forEach`.
+     */
     public fun forEachEntry(action: (Map.Entry<K, V>) -> Unit): Unit
 
+    /**
+        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
+        another map [m].
+
+        The [merger] function is called for each key that is present in either map, with the key, the value from this
+        map, and the value from [m], in that order, as arguments.  If the key is not present in one of the maps, the
+        corresponding [merger] argument will be `null`.
+
+        If the [merger] function returns null, the key is not added to the resulting map.
+     */
     public fun merge(
         m: Map<K, V>,
         merger: (K, V?, V?) -> V?
     ): TreapMap<K, V>
 
+    /**
+        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
+        another map [m].
+
+        The [merger] function is called for each key that is present in either map, with the key, the value from this
+        map, and the value from [m], in that order, as arguments.  If the key is not present in one of the maps, the
+        corresponding [merger] argument will be `null`.
+
+        If the [merger] function returns null, the key is not added to the resulting map.
+
+        Merge operations are performed in parallel for maps larger than (approximately) 2^parallelThresholdLog2.
+     */
     public fun parallelMerge(
         m: Map<K, V>,
         parallelThresholdLog2: Int = 4,
@@ -68,12 +95,23 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
         transform: (K, V) -> R?
     ): TreapMap<K, R>
 
+    /**
+        Produces a new [TreapMap] with the entry for the specified [key] updated via [merger].
+
+        [merger] is called with the current value for the key (or null if the key is absent), and supplied [value]
+        argument.  If the [merger] function returns null, the key will be absent from the resulting map.  Otherwise
+        the resulting map will contain the key with the value returned by the [merger] function.
+     */
     public fun <U> updateEntry(
         key: K,
         value: U,
         merger: (V?, U) -> V?
     ): TreapMap<K, V>
 
+    /**
+        Produces a sequence from the entries of this map and another map.  For each key, the result is an entry mapping
+        the key to a pair of values.  Each value may be null, if the key is not present in the corresponding map.
+     */
     public fun zip(
         m: Map<out K, V>
     ): Sequence<Map.Entry<K, Pair<V?, V?>>>

--- a/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
@@ -36,6 +36,58 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
     public fun forEachEntry(action: (Map.Entry<K, V>) -> Unit): Unit
 
     /**
+        Produces a new map containing the keys from this map and another map [m].
+
+        If a key is present in just one of the maps, the resulting map will contain the key with the corresponding value
+        from that map.  If a key is present in both maps, [merger] is called with the key, the value from this map, and
+        the value from [m], in that order, and the returned value will appear in the resulting map.
+     */
+    public fun union(
+        m: Map<K, V>,
+        merger: (K, V, V) -> V
+    ): TreapMap<K, V>
+
+    /**
+        Produces a new map containing the keys from this map and another map [m].
+
+        If a key is present in just one of the maps, the resulting map will contain the key with the corresponding value
+        from that map.  If a key is present in both maps, [merger] is called with the key, the value from this map, and
+        the value from [m], in that order, and the returned value will appear in the resulting map.
+
+        Merge operations are performed in parallel for maps larger than (approximately) 2^parallelThresholdLog2.
+     */
+    public fun parallelUnion(
+        m: Map<K, V>,
+        parallelThresholdLog2: Int = 4,
+        merger: (K, V, V) -> V
+    ): TreapMap<K, V>
+
+    /**
+        Produces a new map containing the keys that are present in both this map and another map [m].
+
+        For each key, the resulting map will contain the key with the value returned by [merger], which is called with
+        the key, the value from this map, and the value from [m], in that order.
+     */
+    public fun intersect(
+        m: Map<K, V>,
+        merger: (K, V, V) -> V
+    ): TreapMap<K, V>
+
+    /**
+        Produces a new map containing the keys that are present in both this map and another map [m].
+
+        For each key, the resulting map will contain the key with the value returned by [merger], which is called with
+        the key, the value from this map, and the value from [m], in that order.
+
+        Merge operations are performed in parallel for maps larger than (approximately) 2^parallelThresholdLog2.
+     */
+    public fun parallelIntersect(
+        m: Map<K, V>,
+        parallelThresholdLog2: Int = 4,
+        merger: (K, V, V) -> V
+    ): TreapMap<K, V>
+
+    /**
         Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
         another map [m].
 

--- a/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
+++ b/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
@@ -424,6 +424,66 @@ abstract class TreapMapTest {
     }
 
     @Test
+    fun union() {
+        assertEquals(testMapOf(), testMapOf().union(testMapOf()) { _, a, _ -> a })
+        assertEquals(testMapOf(1 to 2), testMapOf(1 to 2).union(testMapOf()) { _, a, _ -> a })
+        assertEquals(testMapOf(1 to 2), testMapOf().union(testMapOf(1 to 2)) { _, a, _ -> a })
+        assertEquals(
+            testMapOf(1 to 2, 2 to 3, 3 to 4),
+            testMapOf(1 to 2, 2 to 3).union(testMapOf(2 to 3, 3 to 4)) { _, a, _ -> a }
+        )
+
+        val m1 = testMapOf(2 to 2, 3 to 3)
+        val m2 = testMapOf(3 to 4)
+        assertEquals(
+            mapOf(2 to 2, 3 to 3),
+            m1.union(m2) { _, a, _ -> a }
+        )
+        assertEquals(
+            mapOf(2 to 2, 3 to 4),
+            m2.union(m1) { _, a, _ -> a }
+        )
+        assertEquals(
+            mapOf(2 to 2, 3 to 4),
+            m1.union(m2) { _, _, b -> b }
+        )
+        assertEquals(
+            mapOf(2 to 2, 3 to 3),
+            m2.union(m1) { _, _, b -> b }
+        )
+    }
+
+    @Test
+    fun intersect() {
+        assertEquals(testMapOf(), testMapOf().intersect(testMapOf()) { _, a, _ -> a })
+        assertEquals(testMapOf(), testMapOf(1 to 2).intersect(testMapOf()) { _, a, _ -> a })
+        assertEquals(testMapOf(), testMapOf().intersect(testMapOf(1 to 2)) { _, a, _ -> a })
+        assertEquals(
+            testMapOf(2 to 3),
+            testMapOf(1 to 2, 2 to 3).intersect(testMapOf(2 to 3, 3 to 4)) { _, a, _ -> a }
+        )
+
+        val m1 = testMapOf(2 to 2, 3 to 3)
+        val m2 = testMapOf(3 to 4)
+        assertEquals(
+            mapOf(3 to 3),
+            m1.intersect(m2) { _, a, _ -> a }
+        )
+        assertEquals(
+            mapOf(3 to 4),
+            m2.intersect(m1) { _, a, _ -> a }
+        )
+        assertEquals(
+            mapOf(3 to 4),
+            m1.intersect(m2) { _, _, b -> b }
+        )
+        assertEquals(
+            mapOf(3 to 3),
+            m2.intersect(m1) { _, _, b -> b }
+        )
+    }
+
+    @Test
     fun zip() {
         assertEquals(
             setOf<Map.Entry<Int, Pair<Int?, Int?>>>(),


### PR DESCRIPTION
`TreapMap.merge` is a very flexible way to merge two `TreapMap`s, but it has a couple of drawbacks:

1) It always visits every entry in both maps 
2) It doesn't allow `null` values to be added to the result map (because `merge` treats `null` as meaning "remove this entry")

The first issue can be a major performance problem if you're merging two large maps with a relatively small key intersection, and you only need to apply custom merge logic to the keys in the intersection.  This turns out to be very common.

To address this, we add new methods to `TreapMap`:

```kotlin
    public fun union(
        m: Map<K, V>,
        merger: (K, V, V) -> V
    ): TreapMap<K, V>

    public fun intersect(
        m: Map<K, V>,
        merger: (K, V, V) -> V
    ): TreapMap<K, V>
```

These apply the `merger` function only to the intersection of the two maps' keys, and don't permit `merger` to discard entries.  `union` preserves all non-intersecting entries from both maps, while `intersect` discards them.

We also add parallel versions of both functions, following the example of `merge`/`parallelMerge`.

See https://github.com/Certora/EVMVerifier/pull/6819 for an example of where this can be used to get some significant performance benefits.