### PR TITLE
`TreapMap.keys` as `TreapSet`

### DIFF
--- a/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
@@ -4,7 +4,8 @@ package com.certora.collect
     Presents the keys of a [TreapMap] as a [TreapSet].
 
     The idea here is that a `TreapMap<K, *>` is stored with the same Treap structure as a `TreapSet<K>`, so we can very
-    quickly create the corresponding `TreapSet<K>` when needed, in O(1) time.
+    quickly create the corresponding `TreapSet<K>` when needed, in O(n) time (as opposed to the naive O(n*log(n))
+    method).
 
     We lazily initialize the set, so that we don't create it until we need it.  For many operations, we can avoid
     creating the set entirely, and just use the map directly.  However, many operations, e.g. [addAll]/[union] and

--- a/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
@@ -9,10 +9,6 @@ package com.certora.collect
     We lazily initialize the set, so that we don't create it until we need it.  For many operations, we can avoid
     creating the set entirely, and just use the map directly.  However, many operations, e.g. [addAll]/[union] and
     [retainAll/intersect], are much more efficient when we have a [TreapSet], so we create it when needed.
-
-    Note: It would be really nice if we could just treat the [TreapMap] objects themselves as [TreapSet] objects, but
-    this presents some problems.  The most fundamental problem is that the [TreapMap] and [TreapSet] interfaces have
-    methods that are not compatible; for example, they both implement [Iterable], but with different element types.
  */
 internal abstract class AbstractKeySet<@Treapable K, S : TreapSet<K>> : TreapSet<K> {
     /**

--- a/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/AbstractKeySet.kt
@@ -1,0 +1,62 @@
+package com.certora.collect
+
+/**
+    Presents the keys of a [TreapMap] as a [TreapSet].
+
+    The idea here is that a `TreapMap<K, *>` is stored with the same Treap structure as a `TreapSet<K>`, so we can very
+    quickly create the corresponding `TreapSet<K>` when needed, in O(1) time.
+
+    We lazily initialize the set, so that we don't create it until we need it.  For many operations, we can avoid
+    creating the set entirely, and just use the map directly.  However, many operations, e.g. [addAll]/[union] and
+    [retainAll/intersect], are much more efficient when we have a [TreapSet], so we create it when needed.
+
+    Note: It would be really nice if we could just treat the [TreapMap] objects themselves as [TreapSet] objects, but
+    this presents some problems.  The most fundamental problem is that the [TreapMap] and [TreapSet] interfaces have
+    methods that are not compatible; for example, they both implement [Iterable], but with different element types.
+ */
+internal abstract class AbstractKeySet<@Treapable K, S : TreapSet<K>> : TreapSet<K> {
+    /**
+        The map whose keys we are presenting as a set.  We prefer to use the map directly when possible, so we don't
+        need to create the set.
+     */
+    abstract val map: AbstractTreapMap<K, *, *>
+    /**
+        The set of keys.  This is a lazy property so that we don't create the set until we need it.
+     */
+    abstract val keys: Lazy<S>
+
+    @Suppress("Treapability")
+    override fun hashCode() = keys.value.hashCode()
+    override fun equals(other: Any?) = keys.value.equals(other)
+    override fun toString() = keys.value.toString()
+
+    override val size get() = map.size
+    override fun isEmpty() = map.isEmpty()
+    override fun clear() = treapSetOf<K>()
+
+    override operator fun contains(element: K) = map.containsKey(element)
+    override operator fun iterator() = map.entrySequence().map { it.key }.iterator()
+
+    override fun add(element: K) = keys.value.add(element)
+    override fun addAll(elements: Collection<K>) = keys.value.addAll(elements)
+    override fun remove(element: K) = keys.value.remove(element)
+    override fun removeAll(elements: Collection<K>) = keys.value.removeAll(elements)
+    override fun removeAll(predicate: (K) -> Boolean) = keys.value.removeAll(predicate)
+    override fun retainAll(elements: Collection<K>) = keys.value.retainAll(elements)
+
+    override fun single() = map.single().key
+    override fun singleOrNull() = map.singleOrNull()?.key
+    override fun arbitraryOrNull() = map.arbitraryOrNull()?.key
+
+    override fun containsAny(elements: Iterable<K>) = keys.value.containsAny(elements)
+    override fun containsAny(predicate: (K) -> Boolean) = (this as Iterable<K>).any(predicate)
+    override fun containsAll(elements: Collection<K>) = keys.value.containsAll(elements)
+    override fun findEqual(element: K) = keys.value.findEqual(element)
+
+    override fun forEachElement(action: (K) -> Unit) = map.forEachEntry { action(it.key) }
+
+    override fun <R : Any> mapReduce(map: (K) -> R, reduce: (R, R) -> R) =
+        this.map.mapReduce({ k, _ -> map(k) }, reduce)
+    override fun <R : Any> parallelMapReduce(map: (K) -> R, reduce: (R, R) -> R, parallelThresholdLog2: Int) =
+        this.map.parallelMapReduce({ k, _ -> map(k) }, reduce, parallelThresholdLog2)
+}

--- a/collect/src/main/kotlin/com/certora/collect/AbstractTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/AbstractTreapMap.kt
@@ -101,6 +101,7 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
         return when {
             otherMap == null -> false
             otherMap === this -> true
+            otherMap.isEmpty() -> false // NB AbstractTreapMap always contains at least one entry
             else -> otherMap.useAsTreap(
                 { otherTreap -> this.self.deepEquals(otherTreap) },
                 { other.size == this.size && other.entries.all { this.containsEntry(it) }}
@@ -110,6 +111,9 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
 
     override val size: Int get() = computeSize()
     override fun isEmpty(): Boolean = false
+
+    // NB AbstractTreapMap always contains at least one entry
+    override fun single() = singleOrNull() ?: throw IllegalArgumentException("Map contains more than one entry")
 
     override fun containsKey(key: K) =
         key.toTreapKey()?.let { self.find(it) }?.shallowContainsKey(key) ?: false
@@ -137,14 +141,6 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
             override val size get() = this@AbstractTreapMap.size
             override fun isEmpty() = this@AbstractTreapMap.isEmpty()
             override fun iterator() = entrySequence().iterator()
-        }
-
-    override val keys: ImmutableSet<K>
-        get() = object: AbstractSet<K>(), ImmutableSet<K> {
-            override val size get() = this@AbstractTreapMap.size
-            override fun isEmpty() = this@AbstractTreapMap.isEmpty()
-            override operator fun contains(element: K) = containsKey(element)
-            override operator fun iterator() = entrySequence().map { it.key }.iterator()
         }
 
     override val values: ImmutableCollection<V>

--- a/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
@@ -19,6 +19,8 @@ internal class EmptyTreapMap<@Treapable K, V> private constructor() : TreapMap<K
     override fun remove(key: K): TreapMap<K, V> = this
     override fun remove(key: K, value: V): TreapMap<K, V> = this
 
+    override fun single(): Map.Entry<K, V> = throw NoSuchElementException("Empty map.")
+    override fun singleOrNull(): Map.Entry<K, V>? = null
     override fun arbitraryOrNull(): Map.Entry<K, V>? = null
 
     override fun forEachEntry(action: (Map.Entry<K, V>) -> Unit): Unit {}
@@ -66,7 +68,7 @@ internal class EmptyTreapMap<@Treapable K, V> private constructor() : TreapMap<K
         m.asSequence().map { MapEntry(it.key, null to it.value) }
 
     override val entries: ImmutableSet<Map.Entry<K, V>> get() = persistentSetOf<Map.Entry<K, V>>()
-    override val keys: ImmutableSet<K> get() = persistentSetOf<K>()
+    override val keys: TreapSet<K> get() = treapSetOf<K>()
     override val values: ImmutableCollection<V> get() = persistentSetOf<V>()
 
     @Suppress("Treapability", "UNCHECKED_CAST")

--- a/collect/src/main/kotlin/com/certora/collect/HashTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/HashTreapMap.kt
@@ -355,13 +355,13 @@ internal class HashTreapMap<@Treapable K, V>(
     private fun treapSetFromKeys(): HashTreapSet<K> =
         HashTreapSet(treapKey, next?.toKeyList(), left?.treapSetFromKeys(), right?.treapSetFromKeys())
 
-    @Suppress("Treapability")
-    class KeySet<@Treapable K>(
-        override val map: HashTreapMap<K, *>,
-        override val keys: Lazy<HashTreapSet<K>> = lazy { map.treapSetFromKeys() }
-    ) : AbstractKeySet<K, HashTreapSet<K>>()
+    inner class KeySet : AbstractKeySet<K, HashTreapSet<K>>() {
+        override val map get() = this@HashTreapMap
+        override val keys = lazy { treapSetFromKeys() }
+        override fun hashCode() = super.hashCode() // avoids treapability warning
+    }
 
-    override val keys get() = KeySet(this)
+    override val keys get() = KeySet()
 }
 
 internal interface KeyValuePairList<K, V> {

--- a/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
@@ -25,7 +25,7 @@ internal class HashTreapSet<@Treapable E>(
     override fun Iterable<E>.toTreapSetOrNull(): HashTreapSet<E>? =
         (this as? HashTreapSet<E>)
         ?: (this as? TreapSet.Builder<E>)?.build() as? HashTreapSet<E>
-        ?: (this as? HashTreapMap.KeySet<E>)?.keys?.value
+        ?: (this as? HashTreapMap<E, *>.KeySet)?.keys?.value
 
     private inline fun ElementList<E>?.forEachNodeElement(action: (E) -> Unit) {
         var current = this

--- a/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
@@ -230,8 +230,11 @@ internal class HashTreapSet<@Treapable E>(
     }.iterator()
 
     override fun singleOrNull(): E? = element.takeIf { next == null && left == null && right == null }
-    override fun single(): E = element.also {
-        if (next != null || left != null || right != null) { throw IllegalArgumentException("Set contains more than one element") }
+    override fun single(): E {
+        if (next != null || left != null || right != null) {
+            throw IllegalArgumentException("Set contains more than one element")
+        }
+        return element
     }
     override fun arbitraryOrNull(): E? = element
 

--- a/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/HashTreapSet.kt
@@ -25,6 +25,7 @@ internal class HashTreapSet<@Treapable E>(
     override fun Iterable<E>.toTreapSetOrNull(): HashTreapSet<E>? =
         (this as? HashTreapSet<E>)
         ?: (this as? TreapSet.Builder<E>)?.build() as? HashTreapSet<E>
+        ?: (this as? HashTreapMap.KeySet<E>)?.keys?.value
 
     private inline fun ElementList<E>?.forEachNodeElement(action: (E) -> Unit) {
         var current = this
@@ -228,8 +229,10 @@ internal class HashTreapSet<@Treapable E>(
         }
     }.iterator()
 
-    override fun shallowGetSingleElement(): E? = element.takeIf { next == null }
-
+    override fun singleOrNull(): E? = element.takeIf { next == null && left == null && right == null }
+    override fun single(): E = element.also {
+        if (next != null || left != null || right != null) { throw IllegalArgumentException("Set contains more than one element") }
+    }
     override fun arbitraryOrNull(): E? = element
 
     override fun <R : Any> shallowMapReduce(map: (E) -> R, reduce: (R, R) -> R): R {

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
@@ -168,11 +168,11 @@ internal class SortedTreapMap<@Treapable K, V>(
     private fun treapSetFromKeys(): SortedTreapSet<K> =
         SortedTreapSet(treapKey, left?.treapSetFromKeys(), right?.treapSetFromKeys())
 
-    @Suppress("Treapability")
-    class KeySet<@Treapable K>(
-        override val map: SortedTreapMap<K, *>,
-        override val keys: Lazy<SortedTreapSet<K>> = lazy { map.treapSetFromKeys() }
-    ) : AbstractKeySet<K, SortedTreapSet<K>>()
+    inner class KeySet : AbstractKeySet<K, SortedTreapSet<K>>() {
+        override val map get() = this@SortedTreapMap
+        override val keys = lazy { treapSetFromKeys() }
+        override fun hashCode() = super.hashCode() // avoids treapability warning
+    }
 
-    override val keys get() = KeySet(this)
+    override val keys get() = KeySet()
 }

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
@@ -31,6 +31,7 @@ internal class SortedTreapMap<@Treapable K, V>(
         this as? SortedTreapMap<K, V>
         ?: (this as? PersistentMap.Builder<K, V>)?.build() as? SortedTreapMap<K, V>
 
+    override fun singleOrNull(): Map.Entry<K, V>? = MapEntry(key, value).takeIf { left == null && right == null }
     override fun arbitraryOrNull(): Map.Entry<K, V>? = MapEntry(key, value)
 
     override fun getShallowUnionMerger(
@@ -163,4 +164,15 @@ internal class SortedTreapMap<@Treapable K, V>(
         action(this.asEntry())
         right?.forEachEntry(action)
     }
+
+    private fun treapSetFromKeys(): SortedTreapSet<K> =
+        SortedTreapSet(treapKey, left?.treapSetFromKeys(), right?.treapSetFromKeys())
+
+    @Suppress("Treapability")
+    class KeySet<@Treapable K>(
+        override val map: SortedTreapMap<K, *>,
+        override val keys: Lazy<SortedTreapSet<K>> = lazy { map.treapSetFromKeys() }
+    ) : AbstractKeySet<K, SortedTreapSet<K>>()
+
+    override val keys get() = KeySet(this)
 }

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
@@ -51,8 +51,11 @@ internal class SortedTreapSet<@Treapable E>(
     override fun shallowRemoveAll(predicate: (E) -> Boolean): SortedTreapSet<E>? = this.takeIf { !predicate(treapKey) }
     override fun shallowComputeHashCode(): Int = treapKey.hashCode()
     override fun singleOrNull(): E? = treapKey.takeIf { left == null && right == null }
-    override fun single(): E = treapKey.also {
-        if (left != null || right != null) { throw IllegalArgumentException("Set contains more than one element") }
+    override fun single(): E {
+        if (left != null || right != null) {
+            throw IllegalArgumentException("Set contains more than one element")
+        }
+        return treapKey
     }
     override fun arbitraryOrNull(): E? = treapKey
     override fun shallowForEach(action: (element: E) -> Unit): Unit { action(treapKey) }

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
@@ -27,7 +27,7 @@ internal class SortedTreapSet<@Treapable E>(
     override fun Iterable<E>.toTreapSetOrNull(): SortedTreapSet<E>? =
         (this as? SortedTreapSet<E>)
         ?: (this as? PersistentSet.Builder<E>)?.build() as? SortedTreapSet<E>
-        ?: (this as? SortedTreapMap.KeySet<E>)?.keys?.value
+        ?: (this as? SortedTreapMap<E, *>.KeySet)?.keys?.value
 
     override val self get() = this
     override fun iterator(): Iterator<E> = this.asTreapSequence().map { it.treapKey }.iterator()

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapSet.kt
@@ -27,6 +27,7 @@ internal class SortedTreapSet<@Treapable E>(
     override fun Iterable<E>.toTreapSetOrNull(): SortedTreapSet<E>? =
         (this as? SortedTreapSet<E>)
         ?: (this as? PersistentSet.Builder<E>)?.build() as? SortedTreapSet<E>
+        ?: (this as? SortedTreapMap.KeySet<E>)?.keys?.value
 
     override val self get() = this
     override fun iterator(): Iterator<E> = this.asTreapSequence().map { it.treapKey }.iterator()
@@ -49,7 +50,10 @@ internal class SortedTreapSet<@Treapable E>(
     override fun shallowRemove(element: E): SortedTreapSet<E>? = null
     override fun shallowRemoveAll(predicate: (E) -> Boolean): SortedTreapSet<E>? = this.takeIf { !predicate(treapKey) }
     override fun shallowComputeHashCode(): Int = treapKey.hashCode()
-    override fun shallowGetSingleElement(): E = treapKey
+    override fun singleOrNull(): E? = treapKey.takeIf { left == null && right == null }
+    override fun single(): E = treapKey.also {
+        if (left != null || right != null) { throw IllegalArgumentException("Set contains more than one element") }
+    }
     override fun arbitraryOrNull(): E? = treapKey
     override fun shallowForEach(action: (element: E) -> Unit): Unit { action(treapKey) }
     override fun <R : Any> shallowMapReduce(map: (E) -> R, reduce: (R, R) -> R): R = map(treapKey)

--- a/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
@@ -12,6 +12,7 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
     override fun remove(key: K, value: @UnsafeVariance V): TreapMap<K, V>
     override fun putAll(m: Map<out K, @UnsafeVariance V>): TreapMap<K, V>
     override fun clear(): TreapMap<K, V>
+    override val keys: TreapSet<K>
 
     /**
         A [PersistentMap.Builder] that produces a [TreapMap].
@@ -22,6 +23,16 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
 
     @Suppress("Treapability")
     override fun builder(): Builder<K, @UnsafeVariance V> = TreapMapBuilder(this)
+
+    /**
+        If this map contains exactly one entry, returns that entry.  Otherwise, throws.
+     */
+    public fun single(): Map.Entry<K, V>
+
+    /**
+        If this map contains exactly one entry, returns that entry.  Otherwise, returns null
+     */
+    public fun singleOrNull(): Map.Entry<K, V>?
 
     /**
         Returns an arbitrary entry from the map, or null if the map is empty.

--- a/collect/src/main/kotlin/com/certora/collect/TreapSet.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapSet.kt
@@ -40,7 +40,7 @@ public sealed interface TreapSet<out T> : PersistentSet<T> {
     public fun containsAny(predicate: (T) -> Boolean): Boolean
 
     /**
-        If this set contains exactly one element, returns that element.  Otherwise, throws [NoSuchElementException].
+        If this set contains exactly one element, returns that element.  Otherwise, throws.
      */
     public fun single(): T
 


### PR DESCRIPTION
Currently it is quite expensive to do operations like this:

```
set2 = map1.keys intersect set1
```

This is because the `keys` property on `TreapMap` is an `ImmuableSet`, not a `TreapSet`, so the intersection operation must convert it to a `TreapSet` first, using the generic `Set`->`TreapSet` conversion, which is rather expensive.

This is a shame, because a `TreapMap<K, V>` of course is already structured the same way as a `TreapSet<K>`, so the conversion to `TreapSet` should be very cheap.

This PR redefines the `keys` property as a `TreapSet`, and defines efficient implementations of this.  Depending on usage, we can sometimes avoid the conversion to `TreapSet` altogether; if not, we can do the conversion as a straightforward projection of the existing `TreapMap` structure, avoiding most of the overhead of the generic conversion.

We also add `single` and `singleOrNull` methods to `TreapMap`, which are useful in their own right, and can be used to avoid the conversion to `TreapSet` in some cases.