### PR TITLE
Intersection mode for `merge`

### DIFF
--- a/collect/src/main/kotlin/com/certora/collect/AbstractTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/AbstractTreapMap.kt
@@ -1,5 +1,6 @@
 package com.certora.collect
 
+import com.certora.collect.TreapMap.MergeMode
 import com.certora.forkjoin.*
 import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableSet
@@ -66,7 +67,7 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
     /**
         Applies a merge function to all entries in this Treap node.
      */
-    abstract fun getShallowMerger(merger: (K, V?, V?) -> V?): (S?, S?) -> S?
+    abstract fun getShallowMerger(mode: MergeMode, merger: (K, V?, V?) -> V?): (S?, S?) -> S?
     abstract fun getShallowUnionMerger(merger: (K, V, V) -> V): (S, S) -> S
     abstract fun getShallowIntersectMerger(merger: (K, V, V) -> V): (S, S) -> S?
 
@@ -204,10 +205,13 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
         Merges the entries in `m` with the entries in this AbstractTreapMap, applying the "merger" function to get the
         new values for each key.
      */
-    override fun merge(m: Map<K, V>, merger: (K, V?, V?) -> V?): TreapMap<K, V> =
+    override fun merge(m: Map<K, V>, mode: MergeMode, merger: (K, V?, V?) -> V?): TreapMap<K, V> =
         m.useAsTreap(
-            { otherTreap -> self.mergeWith(otherTreap, getShallowMerger(merger)) ?: clear() },
-            { fallbackMerge(m, merger) }
+            { otherTreap ->
+                self.mergeWith(otherTreap, mode, getShallowMerger(mode, merger))
+                    ?: clear()
+            },
+            { fallbackMerge(m, mode, merger) }
         )
 
     /**
@@ -219,21 +223,28 @@ internal sealed class AbstractTreapMap<@Treapable K, V, @Treapable S : AbstractT
 
         @param[merger] The merge function to apply to each pair of entries.  Must be pure and thread-safe.
      */
-    override fun parallelMerge(m: Map<K, V>, parallelThresholdLog2: Int, merger: (K, V?, V?) -> V?): TreapMap<K, V> =
+    override fun parallelMerge(
+        m: Map<K, V>,
+        mode: MergeMode,
+        parallelThresholdLog2: Int,
+        merger: (K, V?, V?) -> V?
+    ): TreapMap<K, V> =
         m.useAsTreap(
-            { otherTreap -> self.parallelMergeWith(otherTreap, parallelThresholdLog2, getShallowMerger(merger)) ?: clear() },
-            { fallbackMerge(m, merger) }
+            { otherTreap ->
+                self.parallelMergeWith(otherTreap, mode, parallelThresholdLog2, getShallowMerger(mode, merger))
+                    ?: clear()
+            },
+            { fallbackMerge(m, mode, merger) }
         )
 
-    private fun fallbackMerge(m: Map<K, V>, merger: (K, V?, V?) -> V?): TreapMap<K, V> {
+    private fun fallbackMerge(m: Map<K, V>, mode: MergeMode, merger: (K, V?, V?) -> V?): TreapMap<K, V> {
         var newThis = clear()
-        for (k in this.keys.asSequence() + m.keys.asSequence()) {
-            if (k !in newThis) {
-                newThis = when (val merged = merger(k, this[k], m[k])) {
-                    null -> newThis.remove(k)
-                    else -> newThis.put(k, merged)
-                }
-            }
+        val keys = when(mode) {
+            MergeMode.UNION -> this.keys union m.keys
+            MergeMode.INTERSECTION -> this.keys intersect m.keys
+        }
+        for (k in keys) {
+            merger(k, this[k], m[k])?.let { newThis = newThis.put(k, it) }
         }
         return newThis
     }
@@ -478,14 +489,16 @@ internal fun <@Treapable K, V, U, @Treapable S : AbstractTreapMap<K, V, S>> S?.u
  */
 internal fun <@Treapable K, V, @Treapable S : AbstractTreapMap<K, V, S>> S?.mergeWith(
     that: S?,
+    mode: MergeMode,
     shallowMerge: (S?, S?) -> S?
 ): S? =
     notForking(this to that) {
-        mergeWithImpl(that, shallowMerge)
+        mergeWithImpl(that, mode, shallowMerge)
     }
 
 internal fun <@Treapable K, V, @Treapable S : AbstractTreapMap<K, V, S>> S?.parallelMergeWith(
     that: S?,
+    mode: MergeMode,
     parallelThresholdLog2: Int,
     shallowMerge: (S?, S?) -> S?
 ): S? =
@@ -496,32 +509,34 @@ internal fun <@Treapable K, V, @Treapable S : AbstractTreapMap<K, V, S>> S?.para
             it.second.isApproximatelySmallerThanLog2(parallelThresholdLog2 - 1)
         }
     ) {
-        mergeWithImpl(that, shallowMerge)
+        mergeWithImpl(that, mode, shallowMerge)
     }
 
 context(ThresholdForker<Pair<S?, S?>>)
 private fun <@Treapable K, V, @Treapable S : AbstractTreapMap<K, V, S>> S?.mergeWithImpl(
     that: S?,
+    mode: MergeMode,
     shallowMerge: (S?, S?) -> S?
 ): S? {
     val (newLeft, newRight, newThis) = when {
         this == null && that == null -> {
             return null
         }
-        this == null || that == null -> {
-            fork(
+        this == null || that == null -> when (mode) {
+            MergeMode.UNION -> fork(
                 this to that,
-                { this?.left.mergeWithImpl(that?.left, shallowMerge) },
-                { this?.right.mergeWithImpl(that?.right, shallowMerge) },
+                { this?.left.mergeWithImpl(that?.left, mode, shallowMerge) },
+                { this?.right.mergeWithImpl(that?.right, mode, shallowMerge) },
                 { shallowMerge(this, that) }
             )
+            MergeMode.INTERSECTION -> return null
         }
         this.comparePriorityTo(that) >= 0 -> {
             val thatSplit = that.split(this)
             fork(
                 this to that,
-                { this.left.mergeWithImpl(thatSplit.left, shallowMerge) },
-                { this.right.mergeWithImpl(thatSplit.right, shallowMerge) },
+                { this.left.mergeWithImpl(thatSplit.left, mode, shallowMerge) },
+                { this.right.mergeWithImpl(thatSplit.right, mode, shallowMerge) },
                 { shallowMerge(this, thatSplit.duplicate) }
             )
         }
@@ -530,8 +545,8 @@ private fun <@Treapable K, V, @Treapable S : AbstractTreapMap<K, V, S>> S?.merge
             val thisSplit = this.split(that)
             fork(
                 this to that,
-                { thisSplit.left.mergeWithImpl(that.left, shallowMerge) },
-                { thisSplit.right.mergeWithImpl(that.right, shallowMerge) },
+                { thisSplit.left.mergeWithImpl(that.left, mode, shallowMerge) },
+                { thisSplit.right.mergeWithImpl(that.right, mode, shallowMerge) },
                 { shallowMerge(thisSplit.duplicate, that) }
             )
         }

--- a/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/EmptyTreapMap.kt
@@ -1,5 +1,6 @@
 package com.certora.collect
 
+import com.certora.collect.TreapMap.MergeMode
 import kotlinx.collections.immutable.*
 
 internal class EmptyTreapMap<@Treapable K, V> private constructor() : TreapMap<K, V>, java.io.Serializable {
@@ -47,20 +48,26 @@ internal class EmptyTreapMap<@Treapable K, V> private constructor() : TreapMap<K
     override fun intersect(m: Map<K, V>, merger: (K, V, V) -> V): TreapMap<K, V> = this
     override fun parallelIntersect(m: Map<K, V>, parallelThresholdLog2: Int, merger: (K, V, V) -> V): TreapMap<K, V> = this
 
-    override fun merge(m: Map<K, V>, merger: (K, V?, V?) -> V?): TreapMap<K, V> {
+    override fun merge(m: Map<K, V>, mode: MergeMode, merger: (K, V?, V?) -> V?): TreapMap<K, V> {
         var map: TreapMap<K, V> = this
-        for ((key, value) in m) {
-            val v = merger(key, null, value)
-            if (v != null) {
-                map = map.put(key, v)
+        if (mode == MergeMode.UNION) {
+            for ((key, value) in m) {
+                val v = merger(key, null, value)
+                if (v != null) {
+                    map = map.put(key, v)
+                }
             }
         }
         return map
     }
 
 
-    override fun parallelMerge(m: Map<K, V>, parallelThresholdLog2: Int, merger: (K, V?, V?) -> V?): TreapMap<K, V> =
-        merge(m, merger)
+    override fun parallelMerge(
+        m: Map<K, V>,
+        mode: MergeMode,
+        parallelThresholdLog2: Int,
+        merger: (K, V?, V?) -> V?
+    ): TreapMap<K, V> = merge(m, mode, merger)
 
     override fun zip(m: Map<out K, V>): Sequence<Map.Entry<K, Pair<V?, V?>>> =
         m.asSequence().map { MapEntry(it.key, null to it.value) }

--- a/collect/src/main/kotlin/com/certora/collect/HashTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/HashTreapMap.kt
@@ -1,5 +1,6 @@
 package com.certora.collect
 
+import com.certora.collect.TreapMap.MergeMode
 import kotlinx.collections.immutable.PersistentMap
 
 /**
@@ -33,21 +34,28 @@ internal class HashTreapMap<@Treapable K, V>(
 
     override fun arbitraryOrNull(): Map.Entry<K, V>? = MapEntry(key, value)
 
-    override fun getShallowMerger(merger: (K, V?, V?) -> V?): (HashTreapMap<K, V>?, HashTreapMap<K, V>?) -> HashTreapMap<K, V>? = { t1, t2 ->
+    override fun getShallowMerger(
+        mode: MergeMode,
+        merger: (K, V?, V?) -> V?
+    ): (HashTreapMap<K, V>?, HashTreapMap<K, V>?) -> HashTreapMap<K, V>? = { t1, t2 ->
         var newPairs: KeyValuePairList.More<K, V>? = null
         t1?.forEachPair { (k, v1) ->
-            val v2 = t2?.shallowGetValue(k)
-            val v = merger(k, v1, v2)
-            if (v != null) {
-                newPairs = KeyValuePairList.More(k, v, newPairs)
-            }
-        }
-        t2?.forEachPair { (k, v2) ->
-            val v1 = t1?.shallowGetValue(k)
-            if (v1 == null) {
+            if (mode == MergeMode.UNION || t2.shallowContainsKey(k)) {
+                val v2 = t2?.shallowGetValue(k)
                 val v = merger(k, v1, v2)
                 if (v != null) {
                     newPairs = KeyValuePairList.More(k, v, newPairs)
+                }
+            }
+        }
+        if (mode == MergeMode.UNION) {
+            t2?.forEachPair { (k, v2) ->
+                val v1 = t1?.shallowGetValue(k)
+                if (v1 == null) {
+                    val v = merger(k, v1, v2)
+                    if (v != null) {
+                        newPairs = KeyValuePairList.More(k, v, newPairs)
+                    }
                 }
             }
         }

--- a/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/SortedTreapMap.kt
@@ -1,5 +1,6 @@
 package com.certora.collect
 
+import com.certora.collect.TreapMap.MergeMode
 import kotlinx.collections.immutable.PersistentMap
 
 /**
@@ -47,7 +48,13 @@ internal class SortedTreapMap<@Treapable K, V>(
         SortedTreapMap(t1.key, v, t1.left, t1.right)
     }
 
-    override fun getShallowMerger(merger: (K, V?, V?) -> V?): (SortedTreapMap<K, V>?, SortedTreapMap<K, V>?) -> SortedTreapMap<K, V>? = { t1, t2 ->
+    override fun getShallowMerger(
+        mode: MergeMode,
+        merger: (K, V?, V?) -> V?
+    ): (SortedTreapMap<K, V>?, SortedTreapMap<K, V>?) -> SortedTreapMap<K, V>? = merge@{ t1, t2 ->
+        if (mode == MergeMode.INTERSECTION && (t1 == null || t2 == null)) {
+            return@merge null
+        }
         val k = (t1 ?: t2)!!.key
         val v1 = t1?.value
         val v2 = t2?.value

--- a/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
+++ b/collect/src/main/kotlin/com/certora/collect/TreapMap.kt
@@ -88,17 +88,24 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
     ): TreapMap<K, V>
 
     /**
-        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
+        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to entries from this map and
         another map [m].
 
-        The [merger] function is called for each key that is present in either map, with the key, the value from this
-        map, and the value from [m], in that order, as arguments.  If the key is not present in one of the maps, the
-        corresponding [merger] argument will be `null`.
+        [mode] selects which entries to merge.  If [mode] is [MergeMode.UNION], all entries from both maps are merged.
+        If [mode] is [MergeMode.INTERSECTION], only entries whose keys appear in both maps are merged.
+
+        The [merger] function is called for each entry to be merged, with the key, the value from this map, and the
+        value from [m], in that order, as arguments.  If the key is not present in one of the maps, the corresponding
+        [merger] value argument will be `null`.
 
         If the [merger] function returns null, the key is not added to the resulting map.
+
+        If the merger function does not need to return null (excluding an entry from the resulting map), consider using
+        [union] or [intersect] instead.
      */
     public fun merge(
         m: Map<K, V>,
+        mode: MergeMode,
         merger: (K, V?, V?) -> V?
     ): TreapMap<K, V>
 
@@ -106,19 +113,75 @@ public sealed interface TreapMap<K, V> : PersistentMap<K, V> {
         Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
         another map [m].
 
-        The [merger] function is called for each key that is present in either map, with the key, the value from this
-        map, and the value from [m], in that order, as arguments.  If the key is not present in one of the maps, the
-        corresponding [merger] argument will be `null`.
+        The [merger] function is called for each entry to be merged, with the key, the value from this map, and the
+        value from [m], in that order, as arguments.  If the key is not present in one of the maps, the corresponding
+        [merger] value argument will be `null`.
+
+        If the [merger] function returns null, the key is not added to the resulting map.
+
+        If the merger function does not need to return null (excluding an entry from the resulting map), consider using
+        [union] or [intersect] instead.
+     */
+    public fun merge(
+        m: Map<K, V>,
+        merger: (K, V?, V?) -> V?
+    ): TreapMap<K, V> = merge(m, MergeMode.UNION, merger)
+
+    /**
+        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to entries from this map and
+        another map [m].
+
+        [mode] selects which entries to merge.  If [mode] is [MergeMode.UNION], all entries from both maps are merged.
+        If [mode] is [MergeMode.INTERSECTION], only entries whose keys appear in both maps are merged.
+
+        The [merger] function is called for each entry to be merged, with the key, the value from this map, and the
+        value from [m], in that order, as arguments.  If the key is not present in one of the maps, the corresponding
+        [merger] value argument will be `null`.
 
         If the [merger] function returns null, the key is not added to the resulting map.
 
         Merge operations are performed in parallel for maps larger than (approximately) 2^parallelThresholdLog2.
+
+        If the merger function does not need to return null (excluding an entry from the resulting map), consider using
+        [parallelUnion] or [parallelIntersect] instead.
+     */
+    public fun parallelMerge(
+        m: Map<K, V>,
+        mode: MergeMode,
+        parallelThresholdLog2: Int = 4,
+        merger: (K, V?, V?) -> V?
+    ): TreapMap<K, V>
+
+    /**
+        Produces a new [TreapMap] with updated entries, by applying supplied [merger] to each entry of this map and
+        another map [m].
+
+        The [merger] function is called for each entry to be merged, with the key, the value from this map, and the
+        value from [m], in that order, as arguments.  If the key is not present in one of the maps, the corresponding
+        [merger] value argument will be `null`.
+
+        If the [merger] function returns null, the key is not added to the resulting map.
+
+        Merge operations are performed in parallel for maps larger than (approximately) 2^parallelThresholdLog2.
+
+        If the merger function does not need to return null (excluding an entry from the resulting map), consider using
+        [parallelUnion] or [parallelIntersect] instead.
      */
     public fun parallelMerge(
         m: Map<K, V>,
         parallelThresholdLog2: Int = 4,
         merger: (K, V?, V?) -> V?
-    ): TreapMap<K, V>
+    ): TreapMap<K, V> = parallelMerge(m, MergeMode.UNION, parallelThresholdLog2, merger)
+
+    /**
+        Controls the behavior of [merge] and [parallelMerge] when the maps have different keys.
+     */
+    public enum class MergeMode {
+        /** Merge all entries from both maps. */
+        UNION,
+        /** Only merge entries whose keys appear in both maps. */
+        INTERSECTION
+    }
 
     /**
         Produces a new [TreapMap] with updated entries, by applying the supplied [transform].  Removes entries for which

--- a/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
+++ b/collect/src/test/kotlin/com/certora/collect/TreapMapTest.kt
@@ -1,6 +1,7 @@
 package com.certora.collect
 
 import com.certora.collect.*
+import com.certora.collect.TreapMap.MergeMode
 import java.util.Random
 import kotlinx.collections.immutable.*
 import kotlinx.serialization.json.Json
@@ -421,6 +422,38 @@ abstract class TreapMapTest {
         assertEquals(
             mapOf(2 to -1),
             m1.merge(m2, merger3))
+    }
+
+    @Test
+    fun mergeIntersectMode() {
+        val merger = { _: Int?, v1: Int?, v2: Int? ->
+            v1!! + v2!!
+        }
+
+        assertEquals(testMapOf(), testMapOf().merge(testMapOf(), MergeMode.INTERSECTION, merger))
+        assertEquals(testMapOf(), testMapOf(1 to 2).merge(testMapOf(), MergeMode.INTERSECTION, merger))
+        assertEquals(testMapOf(), testMapOf().merge(testMapOf(1 to 2), MergeMode.INTERSECTION, merger))
+
+        assertEquals(
+            testMapOf(1 to 3, 3 to 9),
+            testMapOf(1 to 2, 2 to 3, 3 to 4).merge(testMapOf(1 to 1, 3 to 5, 4 to 6), MergeMode.INTERSECTION, merger))
+
+        val m1 = testMapOf(2 to 2, 3 to 3)
+        val m2 = testMapOf(3 to 3)
+        assertEquals(
+            mapOf(3 to 6),
+            m2.merge(m1, MergeMode.INTERSECTION, merger))
+        assertEquals(
+            mapOf(3 to 6),
+            m1.merge(m2, MergeMode.INTERSECTION, merger))
+
+        val merger3 = { _: Int?, _: Int?, _: Int? -> null }
+        assertEquals(
+            mapOf(),
+            m2.merge(m1, MergeMode.INTERSECTION, merger3))
+        assertEquals(
+            mapOf(),
+            m1.merge(m2, MergeMode.INTERSECTION, merger3))
     }
 
     @Test


### PR DESCRIPTION
#19 added the `union` and `intersect` methods to `TreapMap`, which are more efficient than `merge` in the case where we only care about merging the entries that share keys.  However, we also have a need for a function that can apply the full `merge` semantics (including removal of keys), but optimized for the intersection case.  This PR adds `merge` and `parallelMerge` overloads that take a mode argument; the two modes are `UNION` (the existing behavior) and `INTERSECTION` (only includes common keys in the merge).

These are separate overloads, rather than simply adding a new optional parameter to the existing ones, because adding a new parameter in the middle of the parameter list would be a breaking change.